### PR TITLE
chore: adjust menu margin

### DIFF
--- a/app/components/LocaleSelector.tsx
+++ b/app/components/LocaleSelector.tsx
@@ -34,7 +34,7 @@ function LocaleSelector() {
         <Languages className="h-5 w-5 md:h-7 md:w-7" />
       </button>
       <div
-        className="absolute -right-2 z-10 -mt-1 hidden w-32 rounded-lg border border-gray-100
+        className="absolute -right-2 z-10 mt-1 hidden w-32 rounded-lg border border-gray-100
       bg-white text-left text-sm shadow-lg group-hover:block dark:bg-black"
       >
         <div className="p-1">

--- a/app/components/ThemeSelector.tsx
+++ b/app/components/ThemeSelector.tsx
@@ -31,7 +31,7 @@ function ThemeSelector() {
         <SunMoon className="h-5 w-5 md:h-7 md:w-7" />
       </button>
       <div
-        className="absolute -right-2 z-10 -mt-1 hidden w-32 rounded-lg border border-gray-100
+        className="absolute -right-2 z-10 mt-1 hidden w-32 rounded-lg border border-gray-100
       bg-white text-left text-sm shadow-lg group-hover:block dark:bg-black"
       >
         <div className="p-1">


### PR DESCRIPTION
<img width="202" alt="Screenshot 2023-09-28 at 00 07 22" src="https://github.com/youngle316/cover-paint/assets/54651817/be9dd592-fc34-45b7-8f58-fd8dda78eeee">
<img width="203" alt="Screenshot 2023-09-28 at 00 04 13" src="https://github.com/youngle316/cover-paint/assets/54651817/a5295554-5b41-4b4c-9877-8cdc629a0843">

Before -> After
---

- Adjust menu items margin from `-mt-1` to `mt-1`